### PR TITLE
update to title of Section 2

### DIFF
--- a/draft-ietf-sipcore-multiple-reasons.md
+++ b/draft-ietf-sipcore-multiple-reasons.md
@@ -36,7 +36,7 @@ The SIP Reason Header Field as defined in RFC 3326 allows only one Reason value 
 
 The SIP Reason Header Field as defined in RFC 3326 allows only one Reason value per protocol value. Experience with more recently defined protocols shows it is useful to allow multiple values with the same protocol value {{STIRREASONS}}. This update to RFC 3326 allows multiple values for an indicated registered protocol when that protocol defines what the presence of multiple values means. It does not change the requirement in RFC 3326 restricting the header field contents to one value per protocol for those protocols that do not define what multiple values mean.
 
-# Conventions and Definitions
+# Conventions
 
 {::boilerplate bcp14-tagged}
 


### PR DESCRIPTION
Should this section title only include either "Conventions" or "Definitions" rather than both? The section only contains the boilerplate paragraph about the key words defined in BCP 14.