### PR TITLE
lowercase "Reason header field"

### DIFF
--- a/draft-ietf-sipcore-multiple-reasons.md
+++ b/draft-ietf-sipcore-multiple-reasons.md
@@ -28,13 +28,13 @@ informative:
 
 --- abstract
 
-The SIP Reason Header Field as defined in RFC 3326 allows only one Reason value per protocol value. Experience with more recently defined protocols shows it is useful to allow multiple values with the same protocol value. This update to RFC 3326 allows multiple values for an indicated registered protocol when that protocol defines what the presence of multiple values means.
+The SIP Reason header field as defined in RFC 3326 allows only one Reason value per protocol value. Experience with more recently defined protocols shows it is useful to allow multiple values with the same protocol value. This update to RFC 3326 allows multiple values for an indicated registered protocol when that protocol defines what the presence of multiple values means.
 
 --- middle
 
 # Introduction
 
-The SIP Reason Header Field as defined in RFC 3326 allows only one Reason value per protocol value. Experience with more recently defined protocols shows it is useful to allow multiple values with the same protocol value {{STIRREASONS}}. This update to RFC 3326 allows multiple values for an indicated registered protocol when that protocol defines what the presence of multiple values means. It does not change the requirement in RFC 3326 restricting the header field contents to one value per protocol for those protocols that do not define what multiple values mean.
+The SIP Reason header field as defined in RFC 3326 allows only one Reason value per protocol value. Experience with more recently defined protocols shows it is useful to allow multiple values with the same protocol value {{STIRREASONS}}. This update to RFC 3326 allows multiple values for an indicated registered protocol when that protocol defines what the presence of multiple values means. It does not change the requirement in RFC 3326 restricting the header field contents to one value per protocol for those protocols that do not define what multiple values mean.
 
 # Conventions and Definitions
 


### PR DESCRIPTION
We suggest updating "Reason Header Field" to "Reason header field" per usage in RFC 3326. In addition, this form is used elsewhere in the RFC Series (see RFCs 6432, 7044, 7544, 8197, and 8606).